### PR TITLE
Test enhancements for RandomDate test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,16 @@
   },
   "require-dev": {
     "php-coveralls/php-coveralls": ">=1",
-    "phpunit/phpunit": ">=4"
+    "phpunit/phpunit": "^4.8.36 || ^9.0"
   },
   "autoload": {
     "psr-4": {
       "joshtronic\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "joshtronic\\Tests\\": "tests/"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+  bootstrap="./vendor/autoload.php"
   colors="true"
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"

--- a/tests/RandomDateTest.php
+++ b/tests/RandomDateTest.php
@@ -1,15 +1,9 @@
 <?php
+namespace joshtronic\Tests;
+use joshtronic\RandomDate;
+use PHPUnit\Framework\TestCase;
 
-require_once './src/RandomDate.php';
-
-if (
-    !class_exists('\PHPUnit_Framework_TestCase')
-    && class_exists('\PHPUnit\Framework\TestCase')
-) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}
-
-class RandomDateTest extends PHPUnit_Framework_TestCase
+class RandomDateTest extends TestCase
 {
     public function testDate()
     {
@@ -19,7 +13,7 @@ class RandomDateTest extends PHPUnit_Framework_TestCase
             $assertRegExp = 'assertRegExp';
         }
 
-        $rd = new joshtronic\RandomDate();
+        $rd = new RandomDate();
         $date = $rd->date('Y-m-d');
 
         $this->$assertRegExp('/^[0-9]{4}(-[0-9]{2}){2}$/i', $date);
@@ -27,7 +21,7 @@ class RandomDateTest extends PHPUnit_Framework_TestCase
 
     public function testMin()
     {
-        $rd = new joshtronic\RandomDate();
+        $rd = new RandomDate();
         $date = $rd->min('yesterday')->date('Y-m-d');
 
         $min = date('Y-m-d', strtotime('yesterday'));
@@ -39,7 +33,7 @@ class RandomDateTest extends PHPUnit_Framework_TestCase
 
     public function testMax()
     {
-        $rd = new joshtronic\RandomDate();
+        $rd = new RandomDate();
         $date = $rd->min('5 days ago')->max('4 days ago')->date('Y-m-d');
 
         $min = date('Y-m-d', strtotime('5 days ago'));
@@ -51,7 +45,7 @@ class RandomDateTest extends PHPUnit_Framework_TestCase
 
     public function testBetween()
     {
-        $rd = new joshtronic\RandomDate();
+        $rd = new RandomDate();
         $date = $rd->between('7 days ago', '6 days ago')->date('Y-m-d');
 
         $min = date('Y-m-d', strtotime('7 days ago'));
@@ -63,7 +57,7 @@ class RandomDateTest extends PHPUnit_Framework_TestCase
 
     public function testReset()
     {
-        $rd = new joshtronic\RandomDate();
+        $rd = new RandomDate();
         $date = $rd->between('+8 days', '+9 days')->date('Y-m-d');
         $date = $rd->reset()->date('Y-m-d');
 


### PR DESCRIPTION
# Changed log

- Add `php-8.0` version test.
- Adding the `phpunit` versions about `^4.8.36 || ^9.0` on `composer.json` for all `PHP` versions.
- Adding the `joshtronic\\Tests\\` namespaces for PHP testing classes.
- Adding `./vendor/autoload.php` for `bootstrap` attribute on `pphunit.xml` file.